### PR TITLE
Use requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+# mpi4py==4.0.3
+syndicate-py==0.19.3
+preserves==0.996.3
+numpy
+torch==2.7.0
+tensorflow==2.19.0

--- a/scripts/setup_env.sh
+++ b/scripts/setup_env.sh
@@ -1,7 +1,4 @@
 conda create -n thesis
 conda init thesis
 conda activate thesis
-pip3 install numpy
-pip3 install syndicate-py
-pip3 install torch
-pip3 install tensorflow
+pip3 install -r ../requirements.txt


### PR DESCRIPTION
Introduces requirements.txt, and uses it in setup_env.sh.

This way we get specific version numbers, and we can both use the same requirements.txt to set up environments.