### PR TITLE
Compression no longer required since syndicate-py 0.19.3 and syndicate-rs 0.44.0-rc.1

### DIFF
--- a/src/data_loader.py
+++ b/src/data_loader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import config
 import numpy as np
-import pickle, gzip, base64
+import pickle, base64
 
 def load_images(filename):
     images = []
@@ -38,11 +38,7 @@ def partition_training_data(images, labels, n):
     return [data[i * chunk_size:(i + 1) * chunk_size] for i in range(n)]
 
 def serialize_data(data):
-    raw = pickle.dumps(data)
-    comp = gzip.compress(raw)
-    return base64.b64encode(comp).decode('ascii')
+    return pickle.dumps(data)
 
 def deserialize_data(data):
-    comp = base64.b64decode(data.encode('ascii'))
-    raw  = gzip.decompress(comp)
-    return pickle.loads(raw)
+    return pickle.loads(data)


### PR DESCRIPTION
Removing compression massively increases the amount of information transferred (factor of 10!) but *speeds up* execution because compression is very slow. This was a problem before syndicate-py 0.19.3 and syndicate-rs 0.44.0-rc.1 because of the accidentally-quadratic behaviours in the Preserves codec and Syndicate relay implementations.